### PR TITLE
Added a 'format' target in the main Makefile to reformat code at once

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ build:
 test: build
 	@cd test && $(MAKE)
 
+format:
+	clang-format -i -style=file src/*.[ch] test/*.[ch]
+
 clean:
 	@cd src && $(MAKE) clean
 	@cd test && $(MAKE) clean


### PR DESCRIPTION
Just to make it easier to reformat the whole thing with clang.
Type 'make format' from time to time.